### PR TITLE
refac: Split development environemnt to production and dev

### DIFF
--- a/dear_j/dear_j/settings.py
+++ b/dear_j/dear_j/settings.py
@@ -9,10 +9,11 @@ https://docs.djangoproject.com/en/4.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
-import datetime
 import pathlib
 
-from dear_j import config as conf
+from utils import ssm
+
+from dear_j import config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
@@ -21,7 +22,7 @@ BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-gkub&ga4g000$!upi9o2svpo85634yaa9+af*mz94d(zl3n4q("
+SECRET_KEY = ssm.get_ssm_parameter(alias="/backend/dearj/django-secret-key")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -63,23 +64,23 @@ REST_FRAMEWORK = {
 }
 
 # settings regarding login
-SITE_ID = conf.SITE_ID
-ACCOUNT_UNIQUE_EMAIL = conf.ACCOUNT_UNIQUE_EMAIL
-ACCOUNT_USER_MODEL_USERNAME_FIELD = conf.ACCOUNT_USER_MODEL_USERNAME_FIELD
-ACCOUNT_USERNAME_REQUIRED = conf.ACCOUNT_USERNAME_REQUIRED
-ACCOUNT_EMAIL_REQUIRED = conf.ACCOUNT_EMAIL_REQUIRED
-ACCOUNT_AUTHENTICATION_METHOD = conf.ACCOUNT_AUTHENTICATION_METHOD
-ACCOUNT_EMAIL_VERIFICATION = conf.ACCOUNT_EMAIL_VERIFICATION
+SITE_ID = config.SITE_ID
+ACCOUNT_UNIQUE_EMAIL = config.ACCOUNT_UNIQUE_EMAIL
+ACCOUNT_USER_MODEL_USERNAME_FIELD = config.ACCOUNT_USER_MODEL_USERNAME_FIELD
+ACCOUNT_USERNAME_REQUIRED = config.ACCOUNT_USERNAME_REQUIRED
+ACCOUNT_EMAIL_REQUIRED = config.ACCOUNT_EMAIL_REQUIRED
+ACCOUNT_AUTHENTICATION_METHOD = config.ACCOUNT_AUTHENTICATION_METHOD
+ACCOUNT_EMAIL_VERIFICATION = config.ACCOUNT_EMAIL_VERIFICATION
 
 # custom dj-rest-auth
-AUTH_USER_MODEL = conf.AUTH_USER_MODEL
-ACCOUNT_ADAPTER = conf.ACCOUNT_ADAPTER
+AUTH_USER_MODEL = config.AUTH_USER_MODEL
+ACCOUNT_ADAPTER = config.ACCOUNT_ADAPTER
 
 # jwt environment setting
-REST_USE_JWT = conf.REST_USE_JWT
-JWT_AUTH_REFRESH_COOKIE = conf.JWT_AUTH_REFRESH_COOKIE
-ACCESS_TOKEN_LIFETIME = conf.ACCESS_TOKEN_LIFETIME
-REFRESH_TOKEN_LIFETIME = conf.REFRESH_TOKEN_LIFETIME
+REST_USE_JWT = config.REST_USE_JWT
+JWT_AUTH_REFRESH_COOKIE = config.JWT_AUTH_REFRESH_COOKIE
+ACCESS_TOKEN_LIFETIME = config.ACCESS_TOKEN_LIFETIME
+REFRESH_TOKEN_LIFETIME = config.REFRESH_TOKEN_LIFETIME
 
 # custom dj-rest-auth (for birthday/username field)
 REST_AUTH_SERIALIZERS = {"USER_DETAILS_SERIALIZER": "user.serializers.CustomUserDetailSerializer"}

--- a/dear_j/dear_j/settings.py
+++ b/dear_j/dear_j/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 import pathlib
 
+import site_env
 from utils import ssm
 
 from dear_j import config
@@ -25,7 +26,7 @@ BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
 SECRET_KEY = ssm.get_ssm_parameter(alias="/backend/dearj/django-secret-key")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = site_env.is_dev()
 
 ALLOWED_HOSTS = []
 

--- a/dear_j/dear_j/settings.py
+++ b/dear_j/dear_j/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/4.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
+import os
 import pathlib
 
 import site_env
@@ -23,7 +24,10 @@ BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = ssm.get_ssm_parameter(alias="/backend/dearj/django-secret-key")
+if site_env.is_prod():
+    SECRET_KEY = ssm.get_ssm_parameter(alias="/backend/dearj/django-secret-key")
+else:
+    SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = site_env.is_dev()
@@ -47,8 +51,8 @@ INSTALLED_APPS = [
     "dj_rest_auth.registration",
     "allauth.account",
     "allauth.socialaccount",
-    "allauth.socialaccount.providers.kakao",
     "allauth.socialaccount.providers.google",
+    "allauth.socialaccount.providers.kakao",
     "user.apps.UserConfig",
 ]
 

--- a/dear_j/site_env.py
+++ b/dear_j/site_env.py
@@ -1,0 +1,18 @@
+import enum
+import os
+
+
+class SiteEnv(enum.Enum):
+    DEV = 1
+    PROD = 2
+
+
+_current_site = SiteEnv[os.environ["SITE"].upper()]
+
+
+def is_dev():
+    return _current_site is SiteEnv.DEV
+
+
+def is_prod():
+    return _current_site is SiteEnv.PROD

--- a/dear_j/utils/ssm.py
+++ b/dear_j/utils/ssm.py
@@ -1,0 +1,6 @@
+import boto3
+
+
+def get_ssm_parameter(alias: str, region_name: str = "ap-northeast-2") -> str:
+    response = boto3.client("ssm", region_name=region_name).get_parameter(Name=alias, WithDecryption=True)
+    return response["Parameter"]["Value"]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,4 +6,3 @@ model-mommy==2.0.0
 pylint==2.13.8
 pytest==7.0.0
 pytest-django==4.5.2
-setuptools==44.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
+boto3==1.24.15
 django==4.1.1
-djangorestframework==3.14.0
-psycopg2-binary==2.9.3; sys_platform == 'darwin' and platform_machine == 'arm64'
-psycopg2==2.9.3; sys_platform != 'darwin' or platform_machine != 'arm64'
-dj-rest-auth==2.2.5
 django-allauth==0.51.0
 django-rest-auth==0.9.5
+djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2
+dj-rest-auth==2.2.5
+psycopg2-binary==2.9.3; sys_platform == 'darwin' and platform_machine == 'arm64'
+psycopg2==2.9.3; sys_platform != 'darwin' or platform_machine != 'arm64'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 boto3==1.24.15
 django==4.1.1
-django-allauth==0.51.0
-django-rest-auth==0.9.5
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2
+django-allauth==0.51.0
+django-rest-auth==0.9.5
 dj-rest-auth==2.2.5
 psycopg2-binary==2.9.3; sys_platform == 'darwin' and platform_machine == 'arm64'
 psycopg2==2.9.3; sys_platform != 'darwin' or platform_machine != 'arm64'


### PR DESCRIPTION
로컬에서 개발시 .env 에 환경변수로 DJANGO_SECRET_KEY 를 넣어두고 쓸수 있습니다.
production 환경에서는 aws secret manage 의 parameter store 에서 해당 값을 읽어와서 쓰도록 했습니다 

아래는 제 .env 세팅입니다
```
PYTHONPATH=./dear_j
DJANGO_SECRET_KEY="..."
SITE=dev
```