### PR TITLE
fix: Add domain to allowed_hosts

### DIFF
--- a/dear_j/dear_j/settings.py
+++ b/dear_j/dear_j/settings.py
@@ -26,6 +26,8 @@ SECRET_KEY = ssm.get_ssm_parameter(alias="/backend/dearj/django-secret-key")
 DEBUG = not site_env.is_prod()
 
 ALLOWED_HOSTS = [
+    "api-dearj-wafflestudio.site", # Prod Domain
+    "api-staging-dearj-wafflestudio.site", # Stage Server
     "ec2-43-201-9-194.ap-northeast-2.compute.amazonaws.com",  # Prod Server
     "ec2-13-124-64-149.ap-northeast-2.compute.amazonaws.com",  # Stage Server
     "127.0.0.1",


### PR DESCRIPTION
- api-dearj-wafflestudio.site, api-staging-wafflestudio.site host를 허용하기 위한 PR입니다. 
